### PR TITLE
PoC: generate static refs from `../_data` folder

### DIFF
--- a/rust/.gitignore
+++ b/rust/.gitignore
@@ -1,2 +1,3 @@
 target
 src/_data
+src/_data.rs

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3,6 +3,28 @@
 version = 3
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+
+[[package]]
+name = "indexmap"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12,9 +34,16 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 name = "kuliya"
 version = "0.1.0"
 dependencies = [
+ "lazy_static",
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "proc-macro2"
@@ -66,6 +95,7 @@ version = "1.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fbd975230bada99c8bb618e0c365c2eefa219158d5c6c29610fd09ff1833257"
 dependencies = [
+ "indexmap",
  "itoa",
  "ryu",
  "serde",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,5 +7,10 @@ build = "gen_data.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+lazy_static = "1.4.0"
 serde = { version = "1.0.194", features = ["derive"] }
 serde_json = "1.0.110"
+
+[build-dependencies]
+serde = { version = "1.0.194", features = ["derive"] }
+serde_json = { version = "1.0.110", features = ["preserve_order"] }

--- a/rust/gen_data.rs
+++ b/rust/gen_data.rs
@@ -1,73 +1,157 @@
-use serde_json::{json, Value};
+use serde::{Deserialize, Serialize};
 use std::{fs, io, path::Path};
 
-fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
-    fs::create_dir_all(&dst)?;
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Name {
+    pub ar: String,
+    pub en: String,
+    pub fr: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub enum Type {
+    #[serde(rename = "UNIVERSITY")]
+    University,
+    #[serde(rename = "ACADEMY")]
+    Academy,
+    #[serde(rename = "PRIVATE_SCHOOL")]
+    PrivateSchool,
+    #[serde(rename = "INSTITUTE")]
+    Institute,
+    #[serde(rename = "FACULTY")]
+    Faculty,
+    #[serde(rename = "DEPARTMENT")]
+    Department,
+    #[serde(rename = "SPECIALTY")]
+    Specialty,
+    #[serde(rename = "SECTOR")]
+    Sector,
+}
+
+impl ToString for Type {
+    fn to_string(&self) -> String {
+        match self {
+            Type::University => format!("Type::University"),
+            Type::Academy => format!("Type::Academy"),
+            Type::PrivateSchool => format!("Type::PrivateSchool"),
+            Type::Institute => format!("Type::Institute"),
+            Type::Faculty => format!("Type::Faculty"),
+            Type::Department => format!("Type::Department"),
+            Type::Specialty => format!("Type::Specialty"),
+            Type::Sector => format!("Type::Sector"),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub struct Terms {
+    #[serde(rename = "perYear")]
+    pub per_year: usize,
+    pub slots: Vec<usize>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Schema {
+    pub name: Name,
+    #[serde(rename = "type")]
+    pub ty: Type,
+    pub terms: Option<Terms>,
+}
+
+fn gen_static_refs(
+    src: impl AsRef<Path>,
+    dst: impl AsRef<Path>,
+    gen_statics: &mut Vec<String>,
+    count: &mut usize,
+) -> io::Result<()> {
     for entry in fs::read_dir(src)? {
         let entry = entry?;
         let ty = entry.file_type()?;
         if ty.is_dir() {
-            copy_dir_all(entry.path(), dst.as_ref().join(entry.file_name()))?;
+            gen_static_refs(
+                entry.path(),
+                dst.as_ref().join(entry.file_name()),
+                gen_statics,
+                count,
+            )?;
         } else {
-            fs::copy(entry.path(), dst.as_ref().join(entry.file_name()))?;
+            let info = fs::read_to_string(entry.path())?;
+            if let Ok(schema) = serde_json::from_str::<Schema>(info.as_str()) {
+                let mut res = String::new();
+                res.push_str(
+                    format!(
+                        r#"
+        Schema {{
+            path: "{}",
+            name: Name {{
+                ar: "{}",
+                en: "{}",
+                fr: "{}",
+            }},
+            ty: {},"#,
+                        entry
+                            .path()
+                            .to_str()
+                            .unwrap()
+                            .trim_end_matches("/info.json")
+                            .trim_start_matches("../_data/"),
+                        schema.name.ar,
+                        schema.name.en,
+                        schema.name.fr,
+                        schema.ty.to_string()
+                    )
+                    .as_str(),
+                );
+                if let Some(terms) = &schema.terms {
+                    res.push_str(
+                        format!(
+                            r#"
+            terms: Some(Terms {{
+                per_year: {},
+                slots: vec![{}],
+            }})
+        }},"#,
+                            terms.per_year,
+                            terms
+                                .slots
+                                .iter()
+                                .map(|e| format!("{}", e))
+                                .collect::<Vec<String>>()
+                                .join(", ")
+                        )
+                        .as_str(),
+                    );
+                } else {
+                    res.push_str(
+                        format!(
+                            r#"
+            terms: None,
+        }},"#
+                        )
+                        .as_str(),
+                    );
+                }
+                gen_statics.push(res);
+                *count += 1;
+            }
         }
     }
     Ok(())
 }
 
-fn directory_to_object(dir: impl AsRef<Path>) -> Value {
-    let info_path = dir.as_ref().join("info.json");
-    let info_dot_json = match info_path.exists() {
-        true => {
-            let info = fs::read_to_string(info_path).unwrap();
-            let info: Value = serde_json::from_str(info.as_str()).unwrap();
-            let mut info = info.as_object().unwrap().clone();
-            info.remove("$schema");
-            Value::Object(info)
-        }
-        false => Value::Object(serde_json::Map::new()),
-    };
-
-    let sub_dirs = fs::read_dir(dir).unwrap();
-    let children = sub_dirs
-        .filter_map(|entry| {
-            let entry = entry.unwrap();
-            let ty = entry.file_type().unwrap();
-            if ty.is_dir() {
-                let file_name = entry.file_name().into_string().unwrap();
-                Some((file_name, directory_to_object(entry.path())))
-            } else {
-                None
-            }
-        })
-        .collect::<serde_json::Map<String, Value>>();
-
-    json!({
-        "info": info_dot_json,
-        "children": children,
-    })
-}
-
-fn generate_data_file() -> Result<(), io::Error> {
-    let json_tree = directory_to_object("../_data");
-    let json_tree = json_tree.get("children").unwrap();
-
+fn generate_data_file(schemas: Vec<String>) -> Result<(), io::Error> {
     let data = format!(
         r##"// This is auto-generated file. Do not edit it manually.
 
+use crate::{{Name, Schema, Terms, Type}};
 use lazy_static::lazy_static;
-use serde_json::Value;
 
 lazy_static! {{
-    pub static ref DATA: Value = {{
-        let data = r#"
-{}
-        "#;
-        serde_json::from_str(data).unwrap()
-    }};
-}}   
+    pub static ref ENTRIES: [Schema; {}] = [{}];
+}}
 "##,
-        serde_json::to_string_pretty(json_tree).unwrap()
+        schemas.len(),
+        schemas.join(""),
     );
 
     fs::write("./src/_data.rs", data)?;
@@ -75,6 +159,14 @@ lazy_static! {{
 }
 
 fn main() {
-    generate_data_file().unwrap();
-    copy_dir_all(Path::new("../_data"), Path::new("./src/_data")).unwrap();
+    let mut schemas: Vec<String> = vec![];
+    let mut count = 0;
+    gen_static_refs(
+        Path::new("../_data"),
+        Path::new("./src/_data"),
+        &mut schemas,
+        &mut count,
+    )
+    .unwrap();
+    generate_data_file(schemas).unwrap();
 }

--- a/rust/gen_data.rs
+++ b/rust/gen_data.rs
@@ -1,3 +1,4 @@
+use serde_json::{json, Value};
 use std::{fs, io, path::Path};
 
 fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
@@ -14,6 +15,66 @@ fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> 
     Ok(())
 }
 
+fn directory_to_object(dir: impl AsRef<Path>) -> Value {
+    let info_path = dir.as_ref().join("info.json");
+    let info_dot_json = match info_path.exists() {
+        true => {
+            let info = fs::read_to_string(info_path).unwrap();
+            let info: Value = serde_json::from_str(info.as_str()).unwrap();
+            let mut info = info.as_object().unwrap().clone();
+            info.remove("$schema");
+            Value::Object(info)
+        }
+        false => Value::Object(serde_json::Map::new()),
+    };
+
+    let sub_dirs = fs::read_dir(dir).unwrap();
+    let children = sub_dirs
+        .filter_map(|entry| {
+            let entry = entry.unwrap();
+            let ty = entry.file_type().unwrap();
+            if ty.is_dir() {
+                let file_name = entry.file_name().into_string().unwrap();
+                Some((file_name, directory_to_object(entry.path())))
+            } else {
+                None
+            }
+        })
+        .collect::<serde_json::Map<String, Value>>();
+
+    json!({
+        "info": info_dot_json,
+        "children": children,
+    })
+}
+
+fn generate_data_file() -> Result<(), io::Error> {
+    let json_tree = directory_to_object("../_data");
+    let json_tree = json_tree.get("children").unwrap();
+
+    let data = format!(
+        r##"// This is auto-generated file. Do not edit it manually.
+
+use lazy_static::lazy_static;
+use serde_json::Value;
+
+lazy_static! {{
+    pub static ref DATA: Value = {{
+        let data = r#"
+{}
+        "#;
+        serde_json::from_str(data).unwrap()
+    }};
+}}   
+"##,
+        serde_json::to_string_pretty(json_tree).unwrap()
+    );
+
+    fs::write("./src/_data.rs", data)?;
+    Ok(())
+}
+
 fn main() {
+    generate_data_file().unwrap();
     copy_dir_all(Path::new("../_data"), Path::new("./src/_data")).unwrap();
 }

--- a/rust/src/api/get_node_by_path.rs
+++ b/rust/src/api/get_node_by_path.rs
@@ -1,0 +1,37 @@
+use crate::{Schema, _data::DATA};
+
+pub fn get_node_by_path(path: &str) -> Option<Schema> {
+    let path = path.trim_start_matches('/');
+    let path = path.trim_end_matches('/');
+    let path = path.split('/').collect::<Vec<_>>();
+
+    let mut node = DATA.clone();
+
+    for part in path {
+        node = node.get(part)?.clone();
+    }
+
+    let node = node.get("info")?.clone();
+    let node: Schema = serde_json::from_value(node).unwrap();
+
+    Some(node)
+}
+
+#[cfg(test)]
+mod test {
+    use crate::api::get_node_by_path::get_node_by_path;
+
+    #[test]
+    fn check_umkb_info() {
+        let result = get_node_by_path("umkb");
+
+        assert_eq!(format!("{:?}", result), "Some(Schema { name: Name { ar: \"جامعة محمد خيضر بسكرة\", en: \"University of Mohamed Khider Biskra\", fr: \"Université Mohamed Khider Biskra\" }, ty: University, terms: None })");
+    }
+
+    #[test]
+    fn check_non_valid_info() {
+        let result = get_node_by_path("non-valid");
+
+        assert_eq!(format!("{:?}", result), "None");
+    }
+}

--- a/rust/src/api/mod.rs
+++ b/rust/src/api/mod.rs
@@ -1,0 +1,1 @@
+pub mod get_node_by_path;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,4 +1,5 @@
 mod _data;
+pub mod api;
 
 use std::fs;
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,3 +1,5 @@
+mod _data;
+
 use std::fs;
 
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
# Description

- Generate static refs and flatten all entries to a fixed size array so they can be assured to be located in the stack.
- Modify `get_node_by_path` function to get the result from that array with O(n) search.

See also #46 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Updated the dataset
