### PR TITLE
hotfix: export `get_node_by_path` function from api module

### DIFF
--- a/rust/build.rs
+++ b/rust/build.rs
@@ -115,8 +115,7 @@ use crate::node::model::{{Node, NodeName, NodeType, NodeTerms}};
 {}
 pub fn get_node_by_path(path: &str) -> Option<&Node> {{
     match path {{
-{}
-        _ => None,
+{}        _ => None,
     }}
 }}"##,
         string_tree.0, string_tree.1
@@ -125,7 +124,9 @@ pub fn get_node_by_path(path: &str) -> Option<&Node> {{
     fs::write("./src/_auto_generated/data.rs", data)?;
     fs::write(
         "./src/_auto_generated/mod.rs",
-        "// This is auto-generated. Do not edit manually\npub mod data;\n",
+        r#"// This is auto-generated. Do not edit manually
+pub mod data;
+"#,
     )?;
     Ok(())
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,3 +1,6 @@
 mod _auto_generated;
-pub mod api;
-pub mod node;
+mod api;
+mod node;
+
+pub use api::get_node_by_path::get_node_by_path;
+pub use node::model::{Node, NodeName, NodeTerms, NodeType};


### PR DESCRIPTION
# Description

- to export `get_node_by_path` function from `api` mod.

See #53 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
