### PR TITLE
exclude build folder from archive

### DIFF
--- a/.github/workflows/c-releases.yml
+++ b/.github/workflows/c-releases.yml
@@ -43,6 +43,7 @@ jobs:
           type: 'tar'
           filename: 'c-release.tar.gz'
           directory: 'c'
+          exclusions: './build/*'
 
       - name: Upload release
         uses: ncipollo/release-action@v1.14.0


### PR DESCRIPTION
# Description

Exclude `build/` folder from archiving.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

